### PR TITLE
Django 1.8 upgrade

### DIFF
--- a/aspc/__init__.py
+++ b/aspc/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery_setup import app as celery_app
+## FIXME: Removed for Django 1.8 upgrade
+# from .celery_setup import app as celery_app

--- a/aspc/auth1/urls.py
+++ b/aspc/auth1/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
 from django.contrib.auth.views import login, logout
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^login/$', login, {'template_name': 'auth/login.html',}, name="login"),
     url(r'^logout/$', logout, {'template_name': 'auth/logged_out.html',}, name="logout"),
-)
+]

--- a/aspc/auth2/urls.py
+++ b/aspc/auth2/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import patterns, url
 from aspc.auth2.views import guest_login, login, logout
 
-urlpatterns = patterns('',
+urlpatterns = [
 	url(r'^guest_login/$', guest_login, name="guest_login"),
 	url(r'^login/$', login, name="login"),
     url(r'^logout/$', logout, name="logout"),
-)
+]

--- a/aspc/celery_setup.py
+++ b/aspc/celery_setup.py
@@ -1,35 +1,36 @@
-from __future__ import absolute_import
-from celery import Celery
-import os
-
+## FIXME: Removed for Django 1.8 upgrade
+# from __future__ import absolute_import
+# from celery import Celery
+# import os
+#
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aspc.settings')
-from django.conf import settings
-
-app = Celery('aspc')
-
+# os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aspc.settings')
+# from django.conf import settings
+#
+# app = Celery('aspc')
+#
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-
-import os.path
-import time
-
-@app.task
-def save_timestamp():
-    """
-    Saves a timestamp to PROJECT_ROOT/celery_test.tmp
-
-    Useful for testing if the workers and result backend are
-    running (also returns the timestamp as a string in the result).
-    """
-    now = time.ctime()
-    outfile = os.path.join(settings.PROJECT_ROOT, 'celery_test.tmp')
-    with open(outfile, 'a') as f:
-        f.write("{0}\n".format(now))
-    return now
-
-@app.task(bind=True)
-def debug_task(self):
-    print('Request: {0!r}'.format(self.request))
+# app.config_from_object('django.conf:settings')
+# app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+#
+# import os.path
+# import time
+#
+# @app.task
+# def save_timestamp():
+#     """
+#     Saves a timestamp to PROJECT_ROOT/celery_test.tmp
+#
+#     Useful for testing if the workers and result backend are
+#     running (also returns the timestamp as a string in the result).
+#     """
+#     now = time.ctime()
+#     outfile = os.path.join(settings.PROJECT_ROOT, 'celery_test.tmp')
+#     with open(outfile, 'a') as f:
+#         f.write("{0}\n".format(now))
+#     return now
+#
+# @app.task(bind=True)
+# def debug_task(self):
+#     print('Request: {0!r}'.format(self.request))

--- a/aspc/configuration.py
+++ b/aspc/configuration.py
@@ -134,7 +134,7 @@ INSTALLED_APPS = (
 	'gunicorn',
 	'django_extensions',
 	'debug_toolbar',
-	'djcelery',
+	#'djcelery',
 	'stdimage',
 	'compressor',
 	'aspc.folio',
@@ -321,9 +321,10 @@ ACADEMIC_TERM_DEFAULTS = {
 }
 
 #### Celery Configuration
-CELERY_RESULT_BACKEND = 'amqp'
-CELERY_TASK_RESULT_EXPIRES = 18000 # 5 hours.
-CELERY_RESULT_PERSISTENT = True
+# FIXME: Removed for Django 1.8 upgrade
+#CELERY_RESULT_BACKEND = 'amqp'
+#CELERY_TASK_RESULT_EXPIRES = 18000 # 5 hours.
+#CELERY_RESULT_PERSISTENT = True
 
 # FIXME: Still need to convert management commands into tasks
 # from celery.schedules import crontab

--- a/aspc/courses/urls.py
+++ b/aspc/courses/urls.py
@@ -3,20 +3,20 @@ from django.conf.urls import *
 from django.views.generic.base import TemplateView
 from aspc.courses.views import CourseDetailView, DepartmentListView, DepartmentCoursesView
 
-urlpatterns = patterns('',
-    (r'^search/$', 'aspc.courses.views.search'),
-    (r'^schedule/$', 'aspc.courses.views.schedule'),
+urlpatterns = [
+    url(r'^search/$', 'aspc.courses.views.search'),
+    url(r'^schedule/$', 'aspc.courses.views.schedule'),
     url(r'^schedule/(?P<course_code>[\w\d-]+)/add/$', 'aspc.courses.views.schedule_course_add', name="course_add"),
     url(r'^schedule/(?P<course_code>[\w\d-]+)/remove/$', 'aspc.courses.views.schedule_course_remove', name="course_remove"),
-    (r'^schedule/(?P<schedule_id>\d+)/$', 'aspc.courses.views.view_schedule'),
-    (r'^schedule/(?P<schedule_id>\d+)/minimal/$', 'aspc.courses.views.view_minimal_schedule'),
-    (r'^schedule/(?P<schedule_id>\d+)/icalendar/$', 'aspc.courses.views.ical_export'),
-    (r'^schedule/icalendar/$', 'aspc.courses.views.ical_export'),
-    (r'^schedule/load/$', 'aspc.courses.views.load_from_session'),
-    (r'^schedule/clear/$', 'aspc.courses.views.clear_schedule'),
-    (r'^schedule/save/$', 'aspc.courses.views.share_schedule'),
+    url(r'^schedule/(?P<schedule_id>\d+)/$', 'aspc.courses.views.view_schedule'),
+    url(r'^schedule/(?P<schedule_id>\d+)/minimal/$', 'aspc.courses.views.view_minimal_schedule'),
+    url(r'^schedule/(?P<schedule_id>\d+)/icalendar/$', 'aspc.courses.views.ical_export'),
+    url(r'^schedule/icalendar/$', 'aspc.courses.views.ical_export'),
+    url(r'^schedule/load/$', 'aspc.courses.views.load_from_session'),
+    url(r'^schedule/clear/$', 'aspc.courses.views.clear_schedule'),
+    url(r'^schedule/save/$', 'aspc.courses.views.share_schedule'),
     url(r'^browse/$', DepartmentListView.as_view(), name="department_list"),
     url(r'^browse/(?P<slug>[A-Z]+)/$', DepartmentCoursesView.as_view(), name="department_detail"),
     url(r'^browse/(?P<dept>[A-Z]+)/(?P<course_code>[\w\d-]+)/$', CourseDetailView.as_view(), name="course_detail"),
     url(r'^$', TemplateView.as_view(template_name='courses/landing.html'), name="coursesearch_home"),
-)
+]

--- a/aspc/coursesearch/urls.py
+++ b/aspc/coursesearch/urls.py
@@ -4,7 +4,7 @@ from django.views.generic.base import TemplateView
 from aspc.coursesearch.views import CourseDetailView, DepartmentListView, DepartmentCoursesView
 from aspc.coursesearch.models import Department, Course
 
-urlpatterns = patterns('',
+urlpatterns = [
     (r'^search/$', 'aspc.coursesearch.views.search'),
     (r'^schedule/$', 'aspc.coursesearch.views.schedule'),
     url(r'^schedule/(?P<course_code>[\w\d-]+)/add/$', 'aspc.coursesearch.views.schedule_course_add', name="course_add"),
@@ -20,4 +20,4 @@ urlpatterns = patterns('',
     url(r'^browse/(?P<slug>[A-Z]+)/$', DepartmentCoursesView.as_view(), name="department_detail"),
     url(r'^browse/(?P<dept>[A-Z]+)/(?P<course_code>[\w\d-]+)/$', CourseDetailView.as_view(), name="course_detail"),
     url(r'^$', TemplateView.as_view(template_name='coursesearch/landing.html'), name="coursesearch_home"),
-)
+]

--- a/aspc/events/urls.py
+++ b/aspc/events/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import patterns, url
 from aspc.events.views import home, event, facebook_page
 
-urlpatterns = patterns('',
+urlpatterns = [
 	url(r'^$', home, name="events"), # /events
 	url(r'^event/(?P<event_id>\d+)?(/)?', event, name="events_detail"), # /events/123
 	url('facebook_page', facebook_page) # /events/facebook_page
-)
+]
 
 # REST structure
 # aspc.pomona.edu/events is the app homepage

--- a/aspc/housing/forms/widgets.py
+++ b/aspc/housing/forms/widgets.py
@@ -25,7 +25,7 @@ class ColumnCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         has_id = attrs and 'id' in attrs
         final_attrs = self.build_attrs(attrs, name=name)
         choices_enum = list(enumerate(chain(self.choices, choices)))
-        
+
         # This is the part that splits the choices into columns.
         # Slices vertically.  Could be changed to slice horizontally, etc.
         column_sizes = columnize(len(choices_enum), self.columns)
@@ -88,13 +88,13 @@ class RoomSelectionWidget(widgets.MultiWidget):
     def __init__(self, buildings=None, attrs=None):
         rswidgets = (widgets.Select(choices=buildings), widgets.TextInput)
         super(RoomSelectionWidget, self).__init__(rswidgets, attrs=attrs)
-    
+
     def decompress(self, value):
         if value:
             print value
         return [None, None]
 
-class RadioInputHTML(widgets.RadioInput):
+class RadioInputHTML(widgets.RadioChoiceInput):
     """
     subclassed for 1 character fix... no <input /> in valid html4
     """
@@ -118,13 +118,13 @@ class RatingRadioFieldRenderer(widgets.RadioFieldRenderer):
     def __getitem__(self, idx):
         choice = self.choices[idx] # Let the IndexError propogate
         return RadioInputHTML(self.name, self.value, self.attrs.copy(), choice, idx)
-    
+
     def render(self):
         """Outputs a <ul> for this set of radio fields."""
         input_tags = list(self)
         last = input_tags.pop()
         first = input_tags.pop(0)
-        
+
         output = u'<label class="low">{0}</label><label class="mobile_high">{1}</label> <span class="rating_control">{2}\n'.format(
             conditional_escape(force_unicode(first.choice_label)),
             conditional_escape(force_unicode(last.choice_label)),

--- a/aspc/housing/urls.py
+++ b/aspc/housing/urls.py
@@ -4,7 +4,7 @@ from aspc.housing.views import Home, RoomDetail, \
     search
 from django.contrib.auth.decorators import login_required
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', Home.as_view(), name="housing_home"),
     url(r'^search/$', search, name="housing_search"),
     url(r'^browse/$', BrowseBuildings.as_view(), name="housing_browse"),
@@ -13,4 +13,4 @@ urlpatterns = patterns('',
     url(r'^browse/(?P<building>[^\s/]+)/(?P<floor>\d)/$', BrowseBuildingFloor.as_view(), name="housing_browse_building_floor"),
     url(r'^browse/(?P<building>[^\s/]+)/(?P<floor>\d)/(?P<room>[A-Za-z0-9]+)/$', RoomDetail.as_view(), name="housing_browse_room"),
     url(r'^browse/(?P<building>[^\s/]+)/(?P<floor>\d)/(?P<room>[A-Za-z0-9]+)/review/$', login_required(ReviewRoom.as_view()), name="housing_review_room"),
-)
+]

--- a/aspc/menu/urls.py
+++ b/aspc/menu/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 from aspc.menu.views import home, weekend, weekday
 
-urlpatterns = patterns('',
+urlpatterns = [
 	url(r'mon', weekday, {'day': 'mon'}, name='mon'),
 	url(r'tue', weekday, {'day': 'tue'}, name='tue'),
 	url(r'wed', weekday, {'day': 'wed'}, name='wed'),
@@ -10,4 +10,4 @@ urlpatterns = patterns('',
 	url(r'sat', weekend, {'day': 'sat'}, name='sat'),
 	url(r'sun', weekend, {'day': 'sun'}, name='sun'),
 	url(r'', home, name='menu')
-)
+]

--- a/aspc/minutes/urls.py
+++ b/aspc/minutes/urls.py
@@ -14,9 +14,9 @@ archive_kwargs.update({
     'allow_empty': True,
 })
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', MinutesArchive.as_view(**archive_kwargs), name="minutes_index"),
     url(r'^(?P<year>\d{4})/$', MinutesYearArchiveView.as_view(**archive_kwargs), name="minutes_year"),
     url(r'^(?P<year>\d{4})/(?P<month>[^/]+)/$', MinutesMonthArchiveView.as_view(**archive_kwargs), name="minutes_month"),
     url(r'^(?P<year>\d{4})/(?P<month>[^/]+)/(?P<day>\d+)/$', MinutesDetail.as_view(**detail_kwargs), name="minutes_detail"),
-)
+]

--- a/aspc/sagelist/urls.py
+++ b/aspc/sagelist/urls.py
@@ -3,10 +3,10 @@ from django.contrib.auth.decorators import login_required
 from aspc.sagelist.views import (CreateBookSaleView, BookSaleDetailView,
     ListBookSalesView, ListUserBookSalesView, BookSaleDeleteView)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', ListBookSalesView.as_view(), name="sagelist"),
     url(r'^create/$', login_required(CreateBookSaleView.as_view()), name="sagelist_create"),
     url(r'^(?P<pk>\d+)/$', BookSaleDetailView.as_view(), name="sagelist_detail"),
     url(r'^(?P<pk>\d+)/delete/$', BookSaleDeleteView.as_view(), name="sagelist_delete"),
     url(r'^(?P<email>[^/]+)/$', ListUserBookSalesView.as_view(), name="sagelist_user_listings"),
-)
+]

--- a/aspc/senate/urls.py
+++ b/aspc/senate/urls.py
@@ -1,9 +1,9 @@
 from django.conf.urls import patterns, include, url
 from aspc.senate.views import DocumentList, AppointmentList, PositionList
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^documents/$', DocumentList.as_view(), name="document_list"),
     url(r'^documents/(?P<page>[0-9]+)/$', DocumentList.as_view(), name="document_list_page"),
     url(r'^positions/$', PositionList.as_view(), name="positions"),
     url(r'^senators/$', AppointmentList.as_view(), name="appointments"),
-)
+]

--- a/aspc/urls.py
+++ b/aspc/urls.py
@@ -15,7 +15,7 @@ import debug_toolbar
 # home_kwargs = post_kwargs.copy()
 # home_kwargs.update({'template_name': 'home.html'})
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', HomeView.as_view(), name="home"),
     url(r'^admin/filebrowser/', include(site.urls)),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
@@ -34,11 +34,9 @@ urlpatterns = patterns('',
     url(r'^rideshare/', lambda request: HttpResponseRedirect('http://5crideshare.com')),
     url(r'(?P<slug_path>(?:[\w\-\d]+/)+)$', 'aspc.folio.views.page_view', name="folio_page"),
     url(r'^__debug__/', include(debug_toolbar.urls)),
-)
+]
 
 if settings.DEBUG:
-    urlpatterns += patterns('',
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.MEDIA_ROOT,
-        }),
-   )
+    urlpatterns.append(
+        url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT})
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=1.7,<1.8
+Django>=1.8,<1.9
 Fabric==1.8.1
 Markdown==2.3.1
 Pillow==2.4.0
-gunicorn==19.2.1
+gunicorn==19.3.0
 python-ldap==2.4.13
 celery==3.1.8
 django-celery==3.1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ Markdown==2.3.1
 Pillow==2.4.0
 gunicorn==19.3.0
 python-ldap==2.4.13
-celery==3.1.8
-django-celery==3.1.16
 django-debug-toolbar==1.1
 django-extensions==1.3.2
 django-filebrowser==3.5.3
@@ -25,3 +23,4 @@ beautifulsoup4==4.3.2
 lxml==3.3.3
 django_compressor==1.4
 python-memcached==1.53
+kombu==3.0.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-ldap==2.4.13
 django-debug-toolbar==1.3
 django-extensions==1.3.2
 django-filebrowser==3.5.3
-django-filter==0.7
+django-filter==0.9.2
 django-grappelli==2.6.3
 django-localflavor==1.0
 django-stdimage==0.5.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ python-twitter==1.1
 feedparser==5.1.3
 beautifulsoup4==4.3.2
 lxml==3.3.3
-django_compressor==1.4
+django_compressor==1.5
 python-memcached==1.53
 kombu==3.0.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Markdown==2.3.1
 Pillow==2.4.0
 gunicorn==19.3.0
 python-ldap==2.4.13
-django-debug-toolbar==1.1
+django-debug-toolbar==1.3
 django-extensions==1.3.2
 django-filebrowser==3.5.3
 django-filter==0.7

--- a/vagrant/init.sh
+++ b/vagrant/init.sh
@@ -75,10 +75,11 @@ rabbitmqctl set_permissions developer ".*" ".*" ".*"
 sudo -u vagrant bash /vagrant/vagrant/init_as_user.sh
 
 # Set up Celery upstart tasks
-cp /vagrant/vagrant/celeryworker.conf /etc/init/
-cp /vagrant/vagrant/celerybeat.conf /etc/init/
-service celeryworker restart && info "Started Celery worker"
-service celerybeat restart && info "Started Celery beat process"
+## FIXME: Removed for Django 1.8 upgrade
+# cp /vagrant/vagrant/celeryworker.conf /etc/init/
+# cp /vagrant/vagrant/celerybeat.conf /etc/init/
+# service celeryworker restart && info "Started Celery worker"
+# service celerybeat restart && info "Started Celery beat process"
 
 # If it's been set up, start a tunnel to Peninsula to reach the course data db
 if [ -f /vagrant/vagrant/ssh_config ];


### PR DESCRIPTION
Upgrades Django to version 1.8 (released April 2015). This is a long-term support release for Django. See https://docs.djangoproject.com/en/1.8/releases/1.8/.

Notable changes:
- Refactors how `urlpatterns` lists are built for routing
- Removes Celery since it wasn't playing nicely and we never got it working properly
- Necessary dependency upgrades