### PR TITLE
Update url for Pomona dining halls 

### DIFF
--- a/aspc/menu/backends/pomona.py
+++ b/aspc/menu/backends/pomona.py
@@ -289,12 +289,12 @@ class PomonaBackend(object):
 			return self._parse_frank_frary_cells(cells)
 
 	def frary_menu(self):
-		return self._get_menu('http://www.pomona.edu/administration/dining/menus/frary.aspx')
+		return self._get_menu('http://www.pomona.edu/administration/dining/menus/frary')
 
 	def frank_menu(self):
-		return self._get_menu('http://www.pomona.edu/administration/dining/menus/frank.aspx')
+		return self._get_menu('http://www.pomona.edu/administration/dining/menus/frank')
 
 	def oldenborg_menu(self):
 		global is_oldenborg
 		is_oldenborg = True;
-		return self._get_menu('http://www.pomona.edu/administration/dining/menus/oldenborg.aspx')
+		return self._get_menu('http://www.pomona.edu/administration/dining/menus/oldenborg')

--- a/aspc/menu/templates/menu/weekday_menu.html
+++ b/aspc/menu/templates/menu/weekday_menu.html
@@ -10,7 +10,7 @@
 		<th>Dinner</th>
 	</tr>
 	<tr id="frank_menu">
-		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frank.aspx" target="_blank">Frank</a></th>
+		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frank" target="_blank">Frank</a></th>
 		<td>
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
@@ -49,7 +49,7 @@
 		</td>
 	</tr>
 	<tr id="frary_menu">
-		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frary.aspx" target="_blank">Frary</a></th>
+		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frary" target="_blank">Frary</a></th>
 		<td>
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
@@ -76,7 +76,7 @@
 		</td>
 	</tr>
 	<tr id="oldenborg_menu">
-		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/oldenborg.aspx" target="_blank">Oldenborg</a></th>
+		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/oldenborg" target="_blank">Oldenborg</a></th>
 		<td>
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>

--- a/aspc/menu/templates/menu/weekend_menu.html
+++ b/aspc/menu/templates/menu/weekend_menu.html
@@ -9,7 +9,7 @@
 		<th>Dinner</th>
 	</tr>
 	<tr id="frank_menu">
-		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frank.aspx" target="_blank">Frank</a></th>
+		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frank" target="_blank">Frank</a></th>
 		<td>
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
@@ -36,7 +36,7 @@
 		</td>
 	</tr>
 	<tr id="frary_menu">
-		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frary.aspx" target="_blank">Frary</a></th>
+		<th class="pomona_background"><a href="http://www.pomona.edu/administration/dining/menus/frary" target="_blank">Frary</a></th>
 		<td>
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>


### PR DESCRIPTION
Updates the url for the Pomona dining halls (remove .*aspx) since the new Pomona site broke the menu for Pomona. Confirmed it's working on staging.

cc @mattdahl @dmsm 