### PR TITLE
Compares senate appointment ids case-insensitively; fixes #46.

### DIFF
--- a/aspc/senate/models.py
+++ b/aspc/senate/models.py
@@ -91,7 +91,7 @@ class Appointment(models.Model):
                 self.user = User.objects.get(email__iexact=self.login_id)
             except User.DoesNotExist:
                 pass
-        elif self.user and not (self.login_id == self.user.email):
+        elif self.user and not (self.login_id.lower() == self.user.email.lower()):
             # The Login ID for an existing Appointment changed, so we need
             # to re-sync / remove permissions for the old account
             old_user = self.user


### PR DESCRIPTION
This should hopefully fix #46. This is an error that traces back to the new authentication system that I deployed last spring. (See https://github.com/aspc/mainsite/commit/d7fca807c8e05e60a88bf78b238d3c24e547e7c2#diff-798483155b1be392fab42185a508fa3dL94). Essentially we used to use usernames to link user accounts and senate appointments, but now we use emails as the id. Problem is that emails are case-insensitive, and we were comparing for exact string matches here. Casting the `login_id` and the `email` fields to lowercase and then comparing should fix this problem, I think. Then the conditional on line 94 will evaluate to `False` after the `sync_permissions()` runs, and the recursion error should be avoided.