### PR TITLE
Forces line breaks in long strings on homepage; fixes #50.

### DIFF
--- a/aspc/static/css/home/blog.css
+++ b/aspc/static/css/home/blog.css
@@ -10,6 +10,7 @@
 }
 
 .news ol.posts {
+	word-wrap: break-word;
 	list-style-type: none;
 	padding: 0;
 	margin: 0;


### PR DESCRIPTION
Re: #50. Problem was this new blog post: https://aspc.pomona.edu/news/2015/Nov/student-representation-critical-thinking-and-writi/. It contains a long URL which wasn't breaking properly, causing the parent div to expand to an unseemly size. Also explains why there was no problem on staging!