### PR TITLE
Forces use of insecure private key for local Vagrant box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,10 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
+  # Use the default insecure private key for SSH (don't need security for this local box)
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+
   # Forward local SSH keys to Vagrant
   config.ssh.forward_agent = true
-  config.ssh.private_key_path = ['~/.ssh/id_rsa', '~/.vagrant.d/insecure_private_key']
 end


### PR DESCRIPTION
I just upgraded to OS X 10.11 El Capitan, and needed to update Vagrant and VirtualBox too. Now running Vagrant 1.8.1 and VirtualBox 5.0.12. In order to successfully boot our box here under that configuration, I had to tell Vagrant to explicitly use its default insecure private key for SSH. I'm pretty sure that was what we were doing before, but just relying on default behavior.

So I don't think this should break anything for anyone else. Anyone else running El Capitan/had trouble with the upgrade? @aspc/digital-media-and-programming-group 