### PR TITLE
Bump Fabric, Pillow, Python-Twitter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.9,<1.9.99
-Fabric==1.8.1
+Fabric>=1.8
 Markdown==2.3.1
-Pillow==2.4.0
+Pillow==2.6.1
 gunicorn==19.3.0
 django-debug-toolbar>=1.4
 django-extensions==1.6.1
@@ -13,7 +13,7 @@ vobject==0.8.2
 psycopg2==2.5.2
 pytz==2013.9
 requests==2.2.0
-python-twitter==1.1
+python-twitter==1.3.1
 feedparser==5.1.3
 beautifulsoup4==4.3.2
 lxml==3.3.3


### PR DESCRIPTION
I couldn't download the old version of these dependencies on new vagrant instance. Fabric isn't used for production. We should see the effects of python-twitter immediately once we push to staging. Pillow (used for image processing of all sorts) is the most worrisome bump - I've only bumped it two minor versions just in case: the [Pillow Changelog](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#240-2014-04-01) didn't seem to mention any breaking changes within those minor version, so I believe we should be safe.