### PR TITLE
Enable course review raffle on admin site

### DIFF
--- a/aspc/housing/admin.py
+++ b/aspc/housing/admin.py
@@ -3,6 +3,8 @@ from django.conf.urls import patterns
 from django.contrib.auth.models import User
 from django.shortcuts import render
 from aspc.housing.models import Room, Review
+from aspc.courses.models import CourseReview
+import random
 
 
 class ReviewAdmin(admin.ModelAdmin):
@@ -25,12 +27,10 @@ class ReviewAdmin(admin.ModelAdmin):
                 start = form.cleaned_data["start_date"]
                 end = form.cleaned_data["end_date"]
                 num = form.cleaned_data["num_winners"]
-                winner_ids = Review.objects\
-                    .filter(create_ts__range=[start, end])\
-                    .order_by('?')[:num]\
-                    .values_list('author', flat=True)
-                winners = User.objects.filter(pk__in=winner_ids)
-                context.update({'winners': winners})
+                reviews = list(Review.objects.filter(create_ts__range=[start, end])) + \
+                    list(CourseReview.objects.filter(created_date__range=[start, end]))
+                winner_reviews = random.sample(reviews, num)
+                context.update({'winner_reviews': winner_reviews})
         else:
             form = RaffleForm()
         context.update({'form': form})

--- a/aspc/housing/templates/housing/raffle.html
+++ b/aspc/housing/templates/housing/raffle.html
@@ -1,9 +1,9 @@
 {% extends "admin/base_site.html" %}
 
-{% block title %}Housing Reviews Raffle{% endblock %}
+{% block title %}Reviews Raffle{% endblock %}
 
 {% block content_title %}
-    <h1>Housing Reviews Raffle</h1>
+    <h1>Reviews Raffle</h1>
 {% endblock %}
 
 {% block content %}
@@ -17,10 +17,11 @@
       {{ form.as_p }}
       <input type="submit" value="Run Raffle"><br><br>
     </form>
-    {% if winners %}
+    {% if winner_reviews %}
     <ul>
-        {% for u in winners %}
-        <li>{{ u.get_full_name }} (<a href="mailto:{{ u.email }}">{{ u.email }}</a>)</li>
+        {% for review in winner_reviews %}
+        <li>{{ review.author.get_full_name }} (<a href="mailto:{{ review.author.email }}">{{ review.author.email }}</a>)
+        {{ review }}</li>
         {% endfor %}
     </ul>
     {% endif %}

--- a/aspc/templates/admin/base.html
+++ b/aspc/templates/admin/base.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block userlinks %}
-	<a href="/admin/housing/review/raffle">{% trans 'Housing reviews raffle' %}</a>
+	<a href="/admin/housing/review/raffle">{% trans 'Course/Housing reviews raffle' %}</a>
 
 	&nbsp;/&nbsp;
 


### PR DESCRIPTION
Currently we can only do housing review raffle on admin site. This PR will add course reviews to the raffle pool and eliminate the need of manual raffle.
