### PR TITLE
Convert character reference notations in menu item names to unicode string

### DIFF
--- a/aspc/menu/templates/menu/weekday_menu.html
+++ b/aspc/menu/templates/menu/weekday_menu.html
@@ -1,5 +1,5 @@
 {% extends "menu/home.html" %}
-
+{% load menu_tag %}
 {% block "outer_content" %}
 {{ block.super }}
 <table id="menu_table">
@@ -18,7 +18,7 @@
 					<li>Closed.</li>
 				{% else %}
 					{% for item in frank_meals.breakfast_items %}
-						<li image_url="{{ item.image_url }}">{{ item }}</li>
+						<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 					{% endfor %}
 				{% endif %}
 			</ul>
@@ -30,7 +30,7 @@
 					<li>Closed.</li>
 				{% else %}
 					{% for item in frank_meals.lunch_items %}
-						<li image_url="{{ item.image_url }}">{{ item }}</li>
+						<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 					{% endfor %}
 				{% endif %}
 			</ul>
@@ -42,7 +42,7 @@
 					<li>Closed.</li>
 				{% else %}
 					{% for item in frank_meals.dinner_items %}
-						<li image_url="{{ item.image_url }}">{{ item }}</li>
+						<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 					{% endfor %}
 				{% endif %}
 			</ul>
@@ -54,7 +54,7 @@
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
 				{% for item in frary_meals.breakfast_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -62,7 +62,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in frary_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -70,7 +70,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in frary_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -87,7 +87,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in oldenborg_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -104,7 +104,7 @@
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
 				{% for item in cmc_meals.breakfast_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -112,7 +112,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in cmc_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -120,7 +120,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in cmc_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -131,7 +131,7 @@
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
 				{% for item in scripps_meals.breakfast_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -139,7 +139,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in scripps_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -147,7 +147,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in scripps_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -158,7 +158,7 @@
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
 				{% for item in pitzer_meals.breakfast_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -166,7 +166,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in pitzer_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -174,7 +174,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in pitzer_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -185,7 +185,7 @@
 			<span class="mobile_meal_header">Breakfast</span>
 			<ul>
 				{% for item in mudd_meals.breakfast_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -193,7 +193,7 @@
 			<span class="mobile_meal_header">Lunch</span>
 			<ul>
 				{% for item in mudd_meals.lunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -201,7 +201,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in mudd_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>

--- a/aspc/menu/templates/menu/weekend_menu.html
+++ b/aspc/menu/templates/menu/weekend_menu.html
@@ -1,5 +1,5 @@
 {% extends "menu/home.html" %}
-
+{% load menu_tag %}
 {% block "outer_content" %}
 {{ block.super }}
 <table id="menu_table">
@@ -17,7 +17,7 @@
 					<li>Closed.</li>
 				{% else %}
 					{% for item in frank_meals.brunch_items %}
-						<li image_url="{{ item.image_url }}">{{ item }}</li>
+						<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 					{% endfor %}
 				{% endif %}
 			</ul>
@@ -29,7 +29,7 @@
 					<li>Closed.</li>
 				{% else %}
 					{% for item in frank_meals.dinner_items %}
-						<li image_url="{{ item.image_url }}">{{ item }}</li>
+						<li image_url="{{ item.image_url }}">{{ item | safe }}</li>
 					{% endfor %}
 				{% endif %}
 			</ul>
@@ -41,7 +41,7 @@
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
 				{% for item in frary_meals.brunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -49,7 +49,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in frary_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -60,7 +60,7 @@
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
 				{% for item in cmc_meals.brunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -68,7 +68,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in cmc_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -79,7 +79,7 @@
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
 				{% for item in scripps_meals.brunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -87,7 +87,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in scripps_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -98,7 +98,7 @@
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
 				{% for item in pitzer_meals.brunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -106,7 +106,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in pitzer_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -117,7 +117,7 @@
 			<span class="mobile_meal_header">Brunch</span>
 			<ul>
 				{% for item in mudd_meals.brunch_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>
@@ -125,7 +125,7 @@
 			<span class="mobile_meal_header">Dinner</span>
 			<ul>
 				{% for item in mudd_meals.dinner_items %}
-					<li image_url="{{ item.image_url }}">{{ item }}</li>
+					<li image_url="{{ item.image_url }}">{{ item.name|clean_item_name }}</li>
 				{% endfor %}
 			</ul>
 		</td>

--- a/aspc/menu/templatetags/__init__.py
+++ b/aspc/menu/templatetags/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'zxiong'

--- a/aspc/menu/templatetags/menu_tag.py
+++ b/aspc/menu/templatetags/menu_tag.py
@@ -1,0 +1,9 @@
+from django import template
+from HTMLParser import HTMLParser
+register = template.Library()
+
+h = HTMLParser()
+
+@register.filter
+def clean_item_name(s):
+    return h.unescape(s)


### PR DESCRIPTION
`"Pesto &#38; Oils, Hummus &#38; Pita Bread" -> "Pesto & Oils, Hummus & Pita Bread" `