### PR TITLE
Remove @method_decorator(login_required) on home and therapist

### DIFF
--- a/aspc/mentalhealth/views.py
+++ b/aspc/mentalhealth/views.py
@@ -34,7 +34,7 @@ class ReviewView(View):
         else:
             therapist = Therapist.objects.get(id=therapist_id).name
             return render(request, 'mentalhealth_reviews/review_new.html', {'therapist_name': therapist, 'form': form})
-@method_decorator(login_required)
+
 def home(request):
     q = request.GET.get("q")
     if q:


### PR DESCRIPTION
The log-in of mental health app would throw '_wrapped_view() takes at least 1 argument (0 given)' if we cover home and therapist with @method_decorator(login_required).