### PR TITLE
Fix Blog attribute error

### DIFF
--- a/aspc/blog/models.py
+++ b/aspc/blog/models.py
@@ -15,7 +15,7 @@ class Post(models.Model):
     def __unicode__(self):
         return u"{0} by {1} ({2}) on {3}".format(
             self.title,
-            self.author.user.get_full_name(),
+            self.author.name,
             self.author.position.title,
             self.posted,
         )

--- a/aspc/blog/templates/blog/post_detail.html
+++ b/aspc/blog/templates/blog/post_detail.html
@@ -15,7 +15,7 @@
 {% endblock %}
 {% block "secondary_content" %}
 <div class="post_info">
-  <span class="byline">posted by {{ post.author.user.get_full_name }}, {{ post.author.position.title }} on {{ post.posted }}</span>
+  <span class="byline">posted by {{ post.author.name }}, {{ post.author.position.title }} on {{ post.posted }}</span>
 </div>
 <div class="post_body content">
   {{ post.body|markdown:"extra"}}


### PR DESCRIPTION
Adding/changing blog in admin interface would give attribute error, and the reason is somehow 'user' is always 'None' for self.author. Currently aspc blog detail fragment correctly shows the author's name, but the complete blog detail doesn't. So I think using 'author.name' (which is used in post_detail_fragment.html) should be a reasonable fix.