### PR TITLE
Add login for previous courses schedules

### DIFF
--- a/aspc/courses/views.py
+++ b/aspc/courses/views.py
@@ -135,7 +135,7 @@ def view_schedule(request, schedule_id):
         return HttpResponseRedirect(reverse('aspc.courses.views.schedule'))
     else:
         return render(request, 'schedule/schedule_frozen.html',{'schedule': schedule,})
-
+@login_required
 def my_schedules(request):
     schedules = request.user.schedule_set.order_by('-create_ts')
     return render(request, 'schedule/my_schedules.html', {'schedules': schedules})


### PR DESCRIPTION
Added login_required to my_schedules (previous course schedules). This prevents the error

> AttributeError at /courses/schedule/my_schedules/
'AnonymousUser' object has no attribute 'schedule_set'

which might be caused by logged-in users who log out and go back to the previous schedules page.