### PR TITLE
Add search by course name api endpoint

### DIFF
--- a/aspc/api/urls.py
+++ b/aspc/api/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url, include
 from aspc.api import views
 from aspc.api.views import (MenuList, MenuDiningHallDetail, MenuDayDetail, MenuDiningHallDayDetail, MenuDiningHallDayMealDetail,
-    InstructorList, InstructorName, CourseList, DepartmentList, CourseInstructor, CourseDepartment)
+    InstructorList, InstructorName, CourseList, CourseName, DepartmentList, CourseInstructor, CourseDepartment)
 
 urlpatterns = [
     url(r'menu/dining_hall/(?P<dining_hall>[^/]+)/day/(?P<day>[^/]+)/meal/(?P<meal>[^/]+)/?$', MenuDiningHallDayMealDetail.as_view()),
@@ -18,6 +18,8 @@ urlpatterns = [
     url(r'courses/instructor/(?P<instructor_id>\d+)/?$', CourseInstructor.as_view()),
     url(r'courses/department/(?P<department_code>[^/]+)/?$', CourseDepartment.as_view()),
     url(r'courses/?$', CourseList.as_view()),
+    url(r'courses/(?P<name>[^/]+)/?$', CourseName.as_view()),
+
 
     url(r'^$', views.api_home, name="api_home"),
 ]

--- a/aspc/api/views.py
+++ b/aspc/api/views.py
@@ -174,6 +174,20 @@ class CourseList(APIView):
         serializer = CourseSerializer(courses, many=True)
         return Response(serializer.data)
 
+class CourseName(APIView):
+    """
+    List courses by name
+    """
+    authentication_classes = (SessionAuthentication, BasicAuthentication, TokenAuthenticationWithQueryString)
+    permission_classes = (IsAuthenticated,)
+    throttle_classes = (UserRateThrottle,)
+
+    def get(self, request, name, format=None):
+        name_tokens = re.split('(?!-)\W+', name)
+        courses = list(Course.objects.filter(reduce(operator.and_,(Q(name__icontains=nt) for nt in name_tokens))).distinct())
+        serializer = CourseSerializer(courses, many=True)
+        return Response(serializer.data)
+
 class CourseDepartment(APIView):
     """
     List all courses


### PR DESCRIPTION
I noticed that you were previously unable to search by course name so I added that API call. It had already been documented within the [API docs](https://www.aspc.pomona.edu/api/) as `/api/courses/{name}/ ` but was not implemented, so I did that. 

Thank you!